### PR TITLE
Update URLs to preview redesign changes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,5 +3,5 @@ Please always provide the [GitHub issue(s)](../issues) your PR is for, as well a
 Fix #<gh-issue-id>
 
 Test URLs:
-- Before: https://main--vg-volvotrucks-us--hlxsites.hlx.page/
-- After: https://<branch>--vg-volvotrucks-us--hlxsites.hlx.page/
+- Before: https://main--vg-volvotrucks-us-redesign--netcentric.hlx.page/
+- After: https://<branch>--vg-volvotrucks-us-redesign--netcentric.hlx.page/

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Volvo Trucks US
-Franklin site for volvotrucks.us
+Franklin site redesign for volvotrucks.us
 
 ## Environments
-- Preview: https://main--vg-volvotrucks-us-redesign--hlxsites.hlx.page/
-- Live: https://main--vg-volvotrucks-us-redesign--hlxsites.hlx.live/
+- Preview: https://main--vg-volvotrucks-us-redesign--netcentric.hlx.page/
+- Live: https://main--vg-volvotrucks-us-redesign--netcentric.hlx.live/
 
 ## Installation
 


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #4 

Test URLs:
- Before: https://main--vg-volvotrucks-us-redesign--netcentric.hlx.page/
- After: https://4-update-readme--vg-volvotrucks-us-redesign--netcentric.hlx.page/
