### PR TITLE
Creating new variables following redesign styleguide + changed base u…

### DIFF
--- a/404.html
+++ b/404.html
@@ -40,7 +40,7 @@
     }
 
     main.error .error-number text {
-      font-family: var(--fixed-font-family);
+      font-family: var(--font-family-fixed);
     }
   </style>
   <link rel="stylesheet" href="/styles/lazy-styles.css">

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 Franklin site for volvotrucks.us
 
 ## Environments
-- Preview: https://main--vg-volvotrucks-us-redesign--hlxsites.hlx.page/
-- Live: https://main--vg-volvotrucks-us-redesign--hlxsites.hlx.live/
+- Preview: https://main--vg-volvotrucks-us-rd--netcentric.hlx.page/
+- Live: https://main--vg-volvotrucks-us-rd--netcentric.hlx.live/
 
 ## Installation
 

--- a/blocks/body-builder-news/body-builder-news.css
+++ b/blocks/body-builder-news/body-builder-news.css
@@ -24,7 +24,7 @@
 }
 
 .bb-news-list .news-item-date {
-    color: #A7A8A9;
+    color: var(--c-grey-2);
 }
 
 .bb-news-list .news-item-content {
@@ -75,7 +75,7 @@
     }
 
     .bb-news-list-small .news-item-metadata {
-        color: #A7A8A9;
+        color: var(--c-grey-2);
         text-transform: uppercase;
         font-size: 16px;
         margin-top: 16px;

--- a/blocks/bullet-points/bullet-points.css
+++ b/blocks/bullet-points/bullet-points.css
@@ -33,7 +33,7 @@
 }
 
 .bullet-points ul li {
-  border-bottom: 1px solid #e1dfdd;
+  border-bottom: 1px solid var(--c-grey-1);
   line-height: 1.3;
   font-size: 16px;
   font-weight: 600;

--- a/blocks/calculator/calculator.css
+++ b/blocks/calculator/calculator.css
@@ -3,7 +3,7 @@ main .section .calculator-wrapper {
 }
 
 .calculator.block {
-  font-family: var(--heading-font-family);
+  font-family: var(--font-family-heading);
   background-color: var(--c-white);
   display: flex;
   flex-direction: column;
@@ -34,7 +34,7 @@ main .section .calculator-wrapper {
 }
 
 .disclaimer {
-  font-family: var(--body-font-family);
+  font-family: var(--font-family-body);
   font-size: var(--body-font-size-xxs);
   font-weight: 400;
   line-height: 16.5px;
@@ -45,7 +45,7 @@ main .section .calculator-wrapper {
 .calculator-inputs-title {
   font-size: var(--body-font-size-s);
   text-transform: uppercase;
-  color: var(--link-color);
+  color: var(--c-cta-blue-default);
   min-height: 50px;
   margin-top: 0;
 }
@@ -80,7 +80,7 @@ main .section .calculator-wrapper {
   font-size: var(--body-font-size-s);
   font-weight: 500;
   height: 52px;
-  border: 1px solid #4d4e53;
+  border: 1px solid var(--c-grey-4);
   border-radius: 0;
   width: 100%;
   padding: 10px 40px 10px 10px;
@@ -124,7 +124,7 @@ main .section .calculator-wrapper {
   color: var(--c-white);
   width: 75%;
   height: 52px;
-  background-color: var(--link-color);
+  background-color: var(--c-cta-blue-default);
   padding: 5px 10px;
   border: none;
   border-radius: 0.25rem;
@@ -148,7 +148,7 @@ main .section .calculator-wrapper {
 }
 
 .calculator-result-wrapper .percentage-wrapper{
-  font-family: var(--body-font-family);
+  font-family: var(--font-family-body);
   display: flex;
   flex-direction: row;
   align-items: center;
@@ -173,7 +173,7 @@ main .section .calculator-wrapper {
 
 .calculator-savings-table {
   text-align: center;
-  font-family: var(--body-font-family);
+  font-family: var(--font-family-body);
   width: 100%;
   padding: 0 15px;
   margin-bottom: 20px;
@@ -200,15 +200,15 @@ main .section .calculator-wrapper {
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
-  font-family: var(--body-font-family);
+  font-family: var(--font-family-body);
   margin: 0 5vw;
 }
 
 .charts-selectors .selector {
   font-size: var(--body-font-size-xxs);
-  color: var(--link-color);
+  color: var(--c-cta-blue-default);
   border-radius: 20px;
-  border: 2px var(--link-color) solid;
+  border: 2px var(--c-cta-blue-default) solid;
   margin: 6px;
   padding: 8px 10px;
   cursor: pointer;
@@ -217,7 +217,7 @@ main .section .calculator-wrapper {
 .charts-selectors .selector:hover,
 .charts-selectors .selector[data-active="true"] {
   color: var(--c-white);
-  background-color: var(--link-color);
+  background-color: var(--c-cta-blue-default);
 }
 
 .charts-wrapper {
@@ -253,7 +253,7 @@ main .section .calculator-wrapper {
   margin: 10px 0 0;
   max-width: 100%;
   height: 100%;
-  font-family: var(--body-font-family);
+  font-family: var(--font-family-body);
   cursor: default;
   z-index: 0;
 }
@@ -291,7 +291,7 @@ main .section .calculator-wrapper {
 }
 
 .charts-wrapper .side-labels .line {
-  stroke: var(--volvo-text-black);
+  stroke: var(--c-black);
   opacity: 0.1;
 }
 

--- a/blocks/calculator/charts/buildChartCumulativeSavings.js
+++ b/blocks/calculator/charts/buildChartCumulativeSavings.js
@@ -1,7 +1,7 @@
 import { calcValuesToPoints, buildReferences } from './chartHelper.js';
 
 const colorGrey2 = getComputedStyle(document.documentElement).getPropertyValue('--c-grey-4');
-const colorLeaf4 = getComputedStyle(document.documentElement).getPropertyValue('--c-leaf-four');
+const colorLeaf4 = getComputedStyle(document.documentElement).getPropertyValue('--c-leaf-4');
 const colorArray = [colorGrey2, colorLeaf4];
 
 // this sets the size of the svg and some measures are taken in relation to that

--- a/blocks/calculator/charts/buildChartCumulativeSavings.js
+++ b/blocks/calculator/charts/buildChartCumulativeSavings.js
@@ -1,6 +1,8 @@
 import { calcValuesToPoints, buildReferences } from './chartHelper.js';
 
-const colorArray = ['#919296', '#77B733'];
+const colorGrey2 = getComputedStyle(document.documentElement).getPropertyValue('--c-grey-4');
+const colorLeaf4 = getComputedStyle(document.documentElement).getPropertyValue('--c-leaf-four');
+const colorArray = [colorGrey2, colorLeaf4];
 
 // this sets the size of the svg and some measures are taken in relation to that
 const totalWidthChart = 800;

--- a/blocks/calculator/charts/buildChartFuelUsage.js
+++ b/blocks/calculator/charts/buildChartFuelUsage.js
@@ -1,6 +1,8 @@
 import { calcValuesToPoints, buildReferences } from './chartHelper.js';
 
-const colorArray = ['#919296', '#77B733'];
+const colorGrey2 = getComputedStyle(document.documentElement).getPropertyValue('--c-grey-4');
+const colorLeaf4 = getComputedStyle(document.documentElement).getPropertyValue('--c-leaf-four');
+const colorArray = [colorGrey2, colorLeaf4];
 
 const totalWidthChart = 800;
 const totalHeightChart = totalWidthChart * 0.6;

--- a/blocks/calculator/charts/buildChartFuelUsage.js
+++ b/blocks/calculator/charts/buildChartFuelUsage.js
@@ -1,7 +1,7 @@
 import { calcValuesToPoints, buildReferences } from './chartHelper.js';
 
 const colorGrey2 = getComputedStyle(document.documentElement).getPropertyValue('--c-grey-4');
-const colorLeaf4 = getComputedStyle(document.documentElement).getPropertyValue('--c-leaf-four');
+const colorLeaf4 = getComputedStyle(document.documentElement).getPropertyValue('--c-leaf-4');
 const colorArray = [colorGrey2, colorLeaf4];
 
 const totalWidthChart = 800;

--- a/blocks/calculator/charts/buildChartMPG.js
+++ b/blocks/calculator/charts/buildChartMPG.js
@@ -1,6 +1,8 @@
 import { calcValuesToPoints, buildReferences } from './chartHelper.js';
 
-const colorArray = ['#919296', '#77B733'];
+const colorGrey2 = getComputedStyle(document.documentElement).getPropertyValue('--c-grey-4');
+const colorLeaf4 = getComputedStyle(document.documentElement).getPropertyValue('--c-leaf-four');
+const colorArray = [colorGrey2, colorLeaf4];
 
 const totalWidthChart = 800;
 const totalHeightChart = totalWidthChart * 0.6;

--- a/blocks/calculator/charts/buildChartMPG.js
+++ b/blocks/calculator/charts/buildChartMPG.js
@@ -1,7 +1,7 @@
 import { calcValuesToPoints, buildReferences } from './chartHelper.js';
 
 const colorGrey2 = getComputedStyle(document.documentElement).getPropertyValue('--c-grey-4');
-const colorLeaf4 = getComputedStyle(document.documentElement).getPropertyValue('--c-leaf-four');
+const colorLeaf4 = getComputedStyle(document.documentElement).getPropertyValue('--c-leaf-4');
 const colorArray = [colorGrey2, colorLeaf4];
 
 const totalWidthChart = 800;

--- a/blocks/calculator/charts/buildChartYearSavings.js
+++ b/blocks/calculator/charts/buildChartYearSavings.js
@@ -1,6 +1,8 @@
 import { calcValuesToPoints, buildReferences } from './chartHelper.js';
 
-const colorArray = ['#919296', '#77B733'];
+const colorGrey2 = getComputedStyle(document.documentElement).getPropertyValue('--c-grey-4');
+const colorLeaf4 = getComputedStyle(document.documentElement).getPropertyValue('--c-leaf-four');
+const colorArray = [colorGrey2, colorLeaf4];
 
 const totalWidthChart = 800;
 const totalHeightChart = totalWidthChart * 0.6;

--- a/blocks/calculator/charts/buildChartYearSavings.js
+++ b/blocks/calculator/charts/buildChartYearSavings.js
@@ -1,7 +1,7 @@
 import { calcValuesToPoints, buildReferences } from './chartHelper.js';
 
 const colorGrey2 = getComputedStyle(document.documentElement).getPropertyValue('--c-grey-4');
-const colorLeaf4 = getComputedStyle(document.documentElement).getPropertyValue('--c-leaf-four');
+const colorLeaf4 = getComputedStyle(document.documentElement).getPropertyValue('--c-leaf-4');
 const colorArray = [colorGrey2, colorLeaf4];
 
 const totalWidthChart = 800;

--- a/blocks/cards/cards.css
+++ b/blocks/cards/cards.css
@@ -9,7 +9,7 @@
 
 .cards > ul > li {
     border: 1px solid var(--highlight-background-color);
-    background-color: var(--background-color)
+    background-color: var(--c-white)
 }
 
 .cards .cards-card-body {

--- a/blocks/cookie-preference-center/cookie-preference-center.css
+++ b/blocks/cookie-preference-center/cookie-preference-center.css
@@ -6,7 +6,7 @@
     font-weight: 700;
     font-family: var(--ff-volvo-novum);
     font-size: var(--body-font-size-xs);
-    border: 2px solid #53565A;
+    border: 2px solid var(--c-grey-4);
 }
 
 .cookie-preference-center a.cta::after {

--- a/blocks/dealer-locator/dealer-locator.css
+++ b/blocks/dealer-locator/dealer-locator.css
@@ -126,7 +126,7 @@ main .section.dealer-locator-container > div {
 }
 
 .dealer-locator .partsasist-form .regForm #select-form #eloquaForm {
-    color: #4d4e53!important
+    color: var(--c-grey-4)!important
 }
 
 .dealer-locator .partsasist-form .regForm #select-form #eloquaForm .field-holder {
@@ -171,7 +171,7 @@ main .section.dealer-locator-container > div {
     height: 350px;
     display: grid;
     align-items: center;
-    border: 15px solid #4d4e53
+    border: 15px solid var(--c-grey-4)
 }
 
 @media (max-width: 991px) {
@@ -195,7 +195,7 @@ main .section.dealer-locator-container > div {
     touch-action: manipulation;
     cursor: pointer;
     background-image: none;
-    border: 2px solid #4d4e53;
+    border: 2px solid var(--c-grey-4);
     white-space: nowrap;
     padding: 12px 32px;
     font-size: 16px;
@@ -203,7 +203,7 @@ main .section.dealer-locator-container > div {
     border-radius: 0;
     user-select: none;
     user-select: none;
-    color: #4d4e53;
+    color: var(--c-grey-4);
     background-color: #FFF
 }
 
@@ -286,7 +286,7 @@ main .section.dealer-locator-container > div {
 
 .dealer-locator .main-directions .go-back button:hover {
     opacity: 1;
-    background-color: #e6e6e6;
+    background-color: var(--c-grey-1);
     border: 1px solid transparent
 }
 
@@ -308,7 +308,7 @@ main .section.dealer-locator-container > div {
 
 .dealer-locator .select-directions .go-back button:hover {
     opacity: 1;
-    background-color: #e6e6e6;
+    background-color: var(--c-grey-1);
     border: 1px solid transparent
 }
 
@@ -329,7 +329,7 @@ main .section.dealer-locator-container > div {
 
 .dealer-locator .go-back-pin button:hover {
     opacity: 1;
-    background-color: #e6e6e6;
+    background-color: var(--c-grey-1);
     border: 1px solid transparent
 }
 
@@ -368,7 +368,7 @@ main .section.dealer-locator-container > div {
 
 .dealer-locator .nearby-pins .panel-card {
     box-shadow: none;
-    border-bottom: 1px solid #e6e6e6;
+    border-bottom: 1px solid var(--c-grey-1);
     cursor: default
 }
 
@@ -464,7 +464,7 @@ main .section.dealer-locator-container > div {
 }
 
 .dealer-locator .nearby-pins article.teaser .teaser-bottom .left .call,.dealer-locator .nearby-pins article.teaser .teaser-bottom .left .direction,.dealer-locator .nearby-pins article.teaser .teaser-bottom .left .more,.dealer-locator .nearby-pins article.teaser .teaser-bottom .right .call,.dealer-locator .nearby-pins article.teaser .teaser-bottom .right .direction,.dealer-locator .nearby-pins article.teaser .teaser-bottom .right .more {
-    border: 1px solid #A7A8A9;
+    border: 1px solid var(--c-grey-2);
     padding: 3px 0 0;
     margin-left: 10px;
     border-radius: 4px;
@@ -489,7 +489,7 @@ main .section.dealer-locator-container > div {
 }
 
 .dealer-locator .nearby-pins article.teaser .teaser-bottom .left .website,.dealer-locator .nearby-pins article.teaser .teaser-bottom .right .website {
-    border: 1px solid #A7A8A9;
+    border: 1px solid var(--c-grey-2);
     padding: 3px 0 0;
     border-radius: 4px;
     width: 69px;
@@ -534,7 +534,7 @@ main .section.dealer-locator-container > div {
 
 .dealer-locator .nearby-select .panel-card {
     box-shadow: none;
-    border-bottom: 1px solid #e6e6e6
+    border-bottom: 1px solid var(--c-grey-1)
 }
 
 .dealer-locator .nearby-select .panel-card:hover {
@@ -690,13 +690,13 @@ main .section.dealer-locator-container > div {
 
 .dealer-locator .go-back-filter button {
     border-radius: 4px;
-    border: 1px solid #A7A8A9;
+    border: 1px solid var(--c-grey-2);
     margin-bottom: 10px
 }
 
 .dealer-locator .go-back-direction button {
     border-radius: 4px;
-    border: 1px solid #A7A8A9;
+    border: 1px solid var(--c-grey-2);
     margin-bottom: 5px
 }
 
@@ -775,7 +775,7 @@ main .section.dealer-locator-container > div {
     }
 
     .dealer-locator .mobile-main-header .panel-header.add-directions:hover {
-        background-color: #e6e6e6
+        background-color: var(--c-grey-1)
     }
 
     .dealer-locator .mobile-main-header .panel-header.to-directions {
@@ -794,8 +794,8 @@ main .section.dealer-locator-container > div {
         border: none;
         z-index: 1;
         background-color: transparent;
-        -webkit-text-fill-color: #4d4e53;
-        color: #4d4e53;
+        -webkit-text-fill-color: var(--c-grey-4);
+        color: var(--c-grey-4);
         transition: all 218ms ease 0s;
         opacity: 1;
         text-align: left;
@@ -982,7 +982,7 @@ main .section.dealer-locator-container > div {
     background: #FFF;
     border-radius: 4px;
     float: right;
-    border: 1px solid #A7A8A9;
+    border: 1px solid var(--c-grey-2);
     right: 0;
     left: 0;
     padding: 1px 6px;
@@ -993,7 +993,7 @@ main .section.dealer-locator-container > div {
 .dealer-locator .sidebar {
     float: left;
     height: 100%;
-    background: #E1DFDD!important;
+    background: var(--c-grey-1)!important;
     left: -408px;
     z-index: 99;
     box-shadow: 5px 0 5px -5px rgb(0 0 0 / 30%);
@@ -1367,7 +1367,7 @@ main .section.dealer-locator-container > div {
     background: 0 0;
     border: 0;
     width: fit-content;
-    border-bottom: 1px solid #e6e6e6
+    border-bottom: 1px solid var(--c-grey-1)
 }
 
 .dealer-locator .sidebar .sidebar-content .pin-actions .join-select {
@@ -1386,7 +1386,7 @@ main .section.dealer-locator-container > div {
     padding: 24px;
     font-size: 13px;
     display: inline-grid;
-    color: #1251B5;
+    color: var(--c-cta-blue-default);
     cursor: pointer;
     opacity: .8;
     outline: 0
@@ -1660,7 +1660,7 @@ main .section.dealer-locator-container > div {
 }
 
 .dealer-locator .sidebar .panel-header.add-directions:hover {
-    background-color: #e6e6e6
+    background-color: var(--c-grey-1)
 }
 
 .dealer-locator .sidebar .panel-header input {
@@ -1675,8 +1675,8 @@ main .section.dealer-locator-container > div {
     border: none;
     z-index: 1;
     background-color: transparent;
-    -webkit-text-fill-color: #4d4e53;
-    color: #4d4e53;
+    -webkit-text-fill-color: var(--c-grey-4);
+    color: var(--c-grey-4);
     transition: all 218ms ease 0s;
     opacity: 1;
     text-align: left;
@@ -1942,7 +1942,7 @@ main .section.dealer-locator-container > div {
     width: 100%;
     height: 15px;
     border-radius: 5px;
-    background: #E1DFDD;
+    background: var(--c-grey-1);
     outline: 0;
     opacity: .7;
     transition: .2s;
@@ -2072,7 +2072,7 @@ main .section.dealer-locator-container > div {
     left: 0;
     height: 25px;
     width: 25px;
-    background-color: #eee;
+    background-color: var(--c-grey-1);
     border-radius: 50%
 }
 
@@ -2417,7 +2417,7 @@ main .section.dealer-locator-container > div {
 
     .sidebar .panel-card {
         box-shadow: none;
-        border-bottom: 1px solid #e6e6e6;
+        border-bottom: 1px solid var(--c-grey-1);
         cursor: default
     }
 

--- a/blocks/dealer-locator/sidebar-maps.js
+++ b/blocks/dealer-locator/sidebar-maps.js
@@ -86,6 +86,11 @@ var uptimeClicked = false;
 $electricDealer = false;
 $hoverText = $('#hoverText').val();
 
+const colorGrey1 = getComputedStyle(document.documentElement).getPropertyValue('--c-grey-1');
+const colorGrey2 = getComputedStyle(document.documentElement).getPropertyValue('--c-grey-2');
+const colorGrey3 = getComputedStyle(document.documentElement).getPropertyValue('--c-grey-3');
+const colorGrey4 = getComputedStyle(document.documentElement).getPropertyValue('--c-grey-4');
+
 // Google callback letting us know maps is ready to be used
 (function () {
   initMap = function () {
@@ -103,7 +108,7 @@ $hoverText = $('#hoverText').val();
           "elementType": "geometry",
           "stylers": [
             {
-              "color": "#f5f5f5"
+              "color": colorGrey1
             }
           ]
         },
@@ -119,7 +124,7 @@ $hoverText = $('#hoverText').val();
           "elementType": "labels.text.fill",
           "stylers": [
             {
-              "color": "#616161"
+              "color": colorGrey4
             }
           ]
         },
@@ -127,7 +132,7 @@ $hoverText = $('#hoverText').val();
           "elementType": "labels.text.stroke",
           "stylers": [
             {
-              "color": "#f5f5f5"
+              "color": colorGrey1
             }
           ]
         },
@@ -136,7 +141,7 @@ $hoverText = $('#hoverText').val();
           "elementType": "labels.text.fill",
           "stylers": [
             {
-              "color": "#bdbdbd"
+              "color": colorGrey2
             }
           ]
         },
@@ -145,7 +150,7 @@ $hoverText = $('#hoverText').val();
           "elementType": "geometry",
           "stylers": [
             {
-              "color": "#eeeeee"
+              "color": colorGrey1
             }
           ]
         },
@@ -154,7 +159,7 @@ $hoverText = $('#hoverText').val();
           "elementType": "labels.text.fill",
           "stylers": [
             {
-              "color": "#757575"
+              "color": colorGrey3
             }
           ]
         },
@@ -190,7 +195,7 @@ $hoverText = $('#hoverText').val();
           "elementType": "labels.text.fill",
           "stylers": [
             {
-              "color": "#757575"
+              "color": colorGrey3
             }
           ]
         },
@@ -208,7 +213,7 @@ $hoverText = $('#hoverText').val();
           "elementType": "labels.text.fill",
           "stylers": [
             {
-              "color": "#616161"
+              "color": colorGrey4
             }
           ]
         },
@@ -235,7 +240,7 @@ $hoverText = $('#hoverText').val();
           "elementType": "geometry",
           "stylers": [
             {
-              "color": "#eeeeee"
+              "color": colorGrey1
             }
           ]
         },

--- a/blocks/document-list/document-list.css
+++ b/blocks/document-list/document-list.css
@@ -13,7 +13,7 @@
 
 .document-list.block a {
     padding: 10px 50px 10px 20px;
-    color: #53565A;
+    color: var(--c-grey-4);
     text-overflow: ellipsis;
     cursor: pointer;
     display: block;

--- a/blocks/eloqua-form/eloqua-form.css
+++ b/blocks/eloqua-form/eloqua-form.css
@@ -32,7 +32,7 @@
   text-align: center;
   vertical-align: middle;
   white-space: nowrap;
-  background: var(--link-color);
+  background: var(--c-cta-blue-default);
   color: var(--c-white);
   border: none;
   margin-bottom: 30px;
@@ -73,7 +73,7 @@
   line-height: 24px;
   margin-top: -12px;
   content: "\f107";
-  color: var(--link-color);
+  color: var(--c-cta-blue-default);
   pointer-events: none;
 }
 

--- a/blocks/eloqua-form/forms/ContactUsVolvo.html
+++ b/blocks/eloqua-form/forms/ContactUsVolvo.html
@@ -190,7 +190,7 @@
     margin-top: 20px;
     margin-bottom: 20px;
     border: 0;
-    border-top: 1px solid #eee
+    border-top: 1px solid var(--c-grey-1);
   }
 
   .elq-form .sr-only {

--- a/blocks/eloqua-form/forms/ExceedingExpectationsSignup.html
+++ b/blocks/eloqua-form/forms/ExceedingExpectationsSignup.html
@@ -182,7 +182,7 @@
     margin-top: 20px;
     margin-bottom: 20px;
     border: 0;
-    border-top: 1px solid #eee
+    border-top: 1px solid var(--c-grey-1);
   }
 
   .elq-form .sr-only {

--- a/blocks/eloqua-form/forms/VNR_Electric_CU.html
+++ b/blocks/eloqua-form/forms/VNR_Electric_CU.html
@@ -180,7 +180,7 @@
     margin-top: 20px;
     margin-bottom: 20px;
     border: 0;
-    border-top: 1px solid #eee
+    border-top: 1px solid var(--c-grey-1);
   }
 
   .elq-form .sr-only {

--- a/blocks/eloqua-form/forms/copyOfTruck19Q3EMTeaserSignUpFR-1582126715298.html
+++ b/blocks/eloqua-form/forms/copyOfTruck19Q3EMTeaserSignUpFR-1582126715298.html
@@ -114,7 +114,7 @@
     margin-top:20px;
     margin-bottom:20px;
     border:0;
-    border-top:1px solid #eee}
+    border-top:1px solid var(--c-grey-1)}
   .elq-form .sr-only{
     position:absolute;
     width:1px;

--- a/blocks/eloqua-form/forms/copyfuelefficient-637860630969151756.html
+++ b/blocks/eloqua-form/forms/copyfuelefficient-637860630969151756.html
@@ -180,7 +180,7 @@
     margin-top: 20px;
     margin-bottom: 20px;
     border: 0;
-    border-top: 1px solid #eee
+    border-top: 1px solid var(--c-grey-1);
   }
 
   .elq-form .sr-only {

--- a/blocks/eloqua-form/forms/event-from.html
+++ b/blocks/eloqua-form/forms/event-from.html
@@ -133,7 +133,7 @@
     margin-top:20px;
     margin-bottom:20px;
     border:0;
-    border-top:1px solid #eee}
+    border-top:1px solid var(--c-grey-1)}
   .elq-form .sr-only{
     position:absolute;
     width:1px;
@@ -707,7 +707,7 @@
   }
 
   .eloqua-form .radio-pill-version input[type="radio"]:checked + label {
-    background: var(--link-color);
+    background: var(--c-cta-blue-default);
     color: white;
   }
 </style>

--- a/blocks/eloqua-form/forms/servicesubscriptions.html
+++ b/blocks/eloqua-form/forms/servicesubscriptions.html
@@ -180,7 +180,7 @@
     margin-top: 20px;
     margin-bottom: 20px;
     border: 0;
-    border-top: 1px solid #eee
+    border-top: 1px solid var(--c-grey-1);
   }
 
   .elq-form .sr-only {

--- a/blocks/eloqua-form/forms/turbo-calculator-form.html
+++ b/blocks/eloqua-form/forms/turbo-calculator-form.html
@@ -118,7 +118,7 @@
     margin-top:20px;
     margin-bottom:20px;
     border:0;
-    border-top:1px solid #eee}
+    border-top:1px solid var(--c-grey-1)}
   .elq-form .sr-only{
     position:absolute;
     width:1px;

--- a/blocks/engine-specifications/engine-specifications.css
+++ b/blocks/engine-specifications/engine-specifications.css
@@ -38,7 +38,7 @@ main .section .engine-specifications-wrapper {
 .engine-specifications .power-title,
 .engine-specifications .torque-title,
 .engine-specifications .item-title {
-  color: #888B8D;
+  color: var(--c-grey-3);
   font-family: var(--ff-volvo-novum);
   margin: 0;
   font-size: var(--body-font-size-xs);
@@ -82,7 +82,7 @@ main .section .engine-specifications-wrapper {
 
 .performance .engine-rating .rating-title {
   font-size: var(--heading-font-size-s);
-  color: #888B8D;
+  color: var(--c-grey-3);
   font-style: normal;
   font-weight: 500;
   line-height: 125%;
@@ -116,7 +116,7 @@ main .section .engine-specifications-wrapper {
 }
 
 .performance .engine-rating .rating-item a:hover {
-  border-bottom: 2px solid #888B8D;
+  border-bottom: 2px solid var(--c-grey-3);
 }
 
 .performance .engine-rating .rating-item[data-active] a {
@@ -170,7 +170,7 @@ main .section .engine-specifications-wrapper {
   font-weight: 400;
   line-height: 130%;
   letter-spacing: 0.5px;
-  fill: #888B8D;
+  fill: var(--c-grey-3);
 }
 
 .peak-rectangle-hp,

--- a/blocks/footer/footer.css
+++ b/blocks/footer/footer.css
@@ -32,7 +32,7 @@
 
 .block.footer .footer-gray a:hover {
   text-decoration: none;
-  color: var(--link-hover-color);
+  color: var(--c-cta-blue-hover);
 }
 
 .block.footer .footer-gray a::after {
@@ -53,9 +53,9 @@
   }
 
   .block.footer .footer-gray h3 {
-    border-top: 1px solid var(--background-color);
+    border-top: 1px solid var(--c-white);
     padding: 20px 1rem;
-    background-color: #E1DFDD;
+    background-color: var(--c-grey-1);
     cursor: pointer;
   }
 
@@ -93,7 +93,7 @@
 /* desktop */
 @media screen and (min-width: 767px) {
   .block.footer .footer-gray {
-    background-color: #E1DFDD;
+    background-color: var(--c-grey-1);
     padding-top: 48px;
     padding-bottom: 28px;
   }
@@ -150,7 +150,7 @@
 
 .block.footer .footer-copyright p {
   margin: 0;
-  color: #A7A8A9;
+  color: var(--c-grey-2);
 }
 
 .block.footer .scroll-to-top {
@@ -161,7 +161,7 @@
   z-index: 99;
   border: none;
   background-color: var(--volvo-text-gray);
-  color: var(--background-color);
+  color: var(--c-white);
   cursor: pointer;
   border-radius: 10px;
   padding: 12px 24px;

--- a/blocks/get-an-offer/get-an-offer.css
+++ b/blocks/get-an-offer/get-an-offer.css
@@ -18,7 +18,7 @@ aside .get-an-offer-sidebar a.button.primary {
     text-align: center;
     vertical-align: middle;
     white-space: nowrap;
-    background: var(--link-color);
+    background: var(--c-cta-blue-default);
     color: var(--c-white);
     border: none;
     margin-bottom: 30px;

--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -45,23 +45,23 @@ header nav .brand .vgsection-location {
 
 /* volvo group section */
 header nav .brand .vgsection-location .vgsection {
-  font-family: var(--body-font-family);
+  font-family: var(--font-family-body);
   color: var(--text-color);
   font-weight: 700;
 }
 
 /* location */
 header nav .vgsection-location .location {
-  font-family: var(--body-font-family);
+  font-family: var(--font-family-body);
   font-weight: 400;
-  color: #a7a8a9;
+  color: var(--c-grey-2);
 }
 
 /* the search icon */
 header nav .search-toggle .search-icon {
   width: 16px;
   height: 16px;
-  color: #a7a8a9;
+  color: var(--c-grey-2);
 }
 
 /* the hamburger icon */
@@ -69,7 +69,7 @@ header nav .hamburger-toggle .hamburger-icon {
   width: 20px;
   height: 14px;
   margin-left: 12px;
-  color: #a7a8a9;
+  color: var(--c-grey-2);
   margin-bottom: 2px;
 }
 
@@ -88,7 +88,7 @@ header nav .search div {
   display: flex;
   flex-flow: row;
   width: 100%;
-  font-family: var(--body-font-family);
+  font-family: var(--font-family-body);
 }
 
 header nav .search-toggle[aria-expanded='true'] ~ .search {
@@ -112,7 +112,7 @@ header nav .search input {
 header nav .search .search-button {
   height: 59px;
   padding: 0 10px;
-  color: #a7a8a9;
+  color: var(--c-grey-2);
   border: none;
   border-radius: 0;
   background-color: #ebebea;
@@ -193,7 +193,7 @@ header nav .tools {
   z-index: 1052;
   background-color: white;
   transition: right 0.2s cubic-bezier(0.4, 0, 0.2, 1) 0.1s;
-  border-bottom: 1px solid #e1dfdd;
+  border-bottom: 1px solid var(--c-grey-1);
 }
 
 header nav .hamburger-toggle[aria-expanded='true'] ~ .tools {
@@ -223,7 +223,7 @@ header nav .tools ul li:first-child {
 }
 
 header nav .tools ul li a {
-  color: #53565a;
+  color: var(--c-grey-4);
   text-decoration: none;
   font-size: 8pt;
 }
@@ -288,7 +288,7 @@ header nav .sections .sections-list ul {
 
 header nav .sections .section {
   line-height: 1.5;
-  color: #53565a;
+  color: var(--c-grey-4);
 }
 
 header nav .sections .section.expand {
@@ -306,7 +306,7 @@ header nav .sections .section a {
 
 header nav .sections .section > a {
   padding: 15px;
-  border-bottom: 1px solid #e1dfdd;
+  border-bottom: 1px solid var(--c-grey-1);
   text-transform: uppercase;
 }
 
@@ -489,7 +489,7 @@ header nav .sections .section .navigation-cta {
   }
 
   header nav .tools ul li a {
-    color: #888b8d;
+    color: var(--c-grey-3);
     font-size: 1.2rem;
   }
 
@@ -524,8 +524,8 @@ header nav .sections .section .navigation-cta {
     padding: 10px 35px 10px 15px;
     width: 290px;
     height: 40px;
-    color: #53565a;
-    border: 1pt solid #e1dfdd;
+    color: var(--c-grey-4);
+    border: 1pt solid var(--c-grey-1);
     border-radius: 0;
     background-color: #fff;
     box-shadow: none;
@@ -555,7 +555,7 @@ header nav .sections .section .navigation-cta {
     grid-area: sections;
     height: 48px;
     width: 100%;
-    background-color: #e1dfdd;
+    background-color: var(--c-grey-1);
   }
 
   header nav .sections .sections-list {
@@ -673,7 +673,7 @@ header nav .sections .section .navigation-cta {
     padding: 0;
     font-size: 14px;
     margin-left: 8px;
-    color: var(--link-color);
+    color: var(--c-cta-blue-default);
   }
 
   header nav .sections .section.expand .navigation-cta a::after {
@@ -726,7 +726,7 @@ header nav .sections .section .navigation-cta {
     position: unset;
     margin-left: 8px;
     font-size: inherit;
-    color: var(--link-color);
+    color: var(--c-cta-blue-default);
     font-weight: 700;
   }
 

--- a/blocks/hero/hero.css
+++ b/blocks/hero/hero.css
@@ -3,189 +3,189 @@ main .section.hero-container {
 }
 
 main .section.hero-container .hero-wrapper {
-    padding: 0;
-    margin: 0;
-    width: 100%;
+  padding: 0;
+  margin: 0;
+  width: 100%;
 }
 
 main .hero {
-    position: relative;
+  position: relative;
 }
 
 main .hero-headings {
-    color: var(--volvo-text-gray);
-    text-align: center;
+  color: var(--volvo-text-gray);
+  text-align: center;
 }
 
 main .hero-headings h1,
 main .hero-headings h4 {
-    max-width: 1200px;
-    margin-left: auto;
-    margin-right: auto;
+  max-width: 1200px;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 main .hero-headings h1 {
-    margin-top: 0;
-    margin-bottom: 36px;
-    font-family: var(--ff-volvo-broadprodigital);
-    font-size: 6rem;
-    letter-spacing: 3.6px;
-    line-height: 1em;
+  margin-top: 0;
+  margin-bottom: 36px;
+  font-family: var(--ff-volvo-broadprodigital);
+  font-size: 6rem;
+  letter-spacing: 3.6px;
+  line-height: 1em;
 }
 
 main .hero-headings h4 {
-    margin-top: 15px;
-    margin-bottom: 8px;
-    font-size: 1.6rem;
-    letter-spacing: -0.1px;
-    line-height: 1.5em;
+  margin-top: 15px;
+  margin-bottom: 8px;
+  font-size: 1.6rem;
+  letter-spacing: -0.1px;
+  line-height: 1.5em;
 }
 
 main .hero-headings:has(.button) h1 {
-    margin-block-end: 8px;
+  margin-block-end: 8px;
 }
 
 main .hero .button-container {
-    margin-block: 0;
+  margin-block: 0;
 }
 
 main .hero picture {
-    object-fit: cover;
-    box-sizing: border-box;
+  object-fit: cover;
+  box-sizing: border-box;
 }
 
 main .hero img {
-    display: block;
-    object-fit: cover;
-    width: 100%;
-    height: 413px;
-    max-height: 413px;
+  display: block;
+  object-fit: cover;
+  width: 100%;
+  height: 413px;
+  max-height: 413px;
 }
 
 main .hero a.cta {
-    display: initial;
-    color: currentcolor;
-    background-color: transparent;
-    border: none;
-    border-radius: unset;
-    padding: 0;
-    margin: 0;
-    font-family: var(--ff-volvo-novum-regular);
-    font-size: var(--body-font-size-xs);
+  display: initial;
+  color: currentcolor;
+  background-color: transparent;
+  border: none;
+  border-radius: unset;
+  padding: 0;
+  margin: 0;
+  font-family: var(--ff-volvo-novum-regular);
+  font-size: var(--body-font-size-xs);
 }
 
 main .hero-with-video picture img {
-    height: 230px;
-    max-height: 230px;
+  height: 230px;
+  max-height: 230px;
 }
 
 main .hero-with-video .hero-video {
-    display: block;
-    width: 100%;
-    max-height: 230px;
-    object-fit: cover;
+  display: block;
+  width: 100%;
+  max-height: 230px;
+  object-fit: cover;
 }
 
 @media screen and (min-width: 481px) {
-    main .hero-headings {
-        color: white;
-        position: absolute;
-        bottom: 16px;
-        padding-left: 32px;
-        text-align: initial;
-    }
+  main .hero-headings {
+    color: white;
+    position: absolute;
+    bottom: 16px;
+    padding-left: 32px;
+    text-align: initial;
+  }
 
-    main .hero-headings h1 {
-        margin-bottom: 8px;
-    }
+  main .hero-headings h1 {
+    margin-bottom: 8px;
+  }
 
-    main .hero-headings h4 {
-        margin-top: 0;
-    }
+  main .hero-headings h4 {
+    margin-top: 0;
+  }
 
-    main .hero picture::after {
-        display: block;
-        content: '';
-        position: absolute;
-        top: 50%;
-        bottom: 0;
-        right: 0;
-        left: 0;
-        background: linear-gradient(-180deg,rgb(0 0 0 / 0%),rgb(0 0 0 / 80%)) repeat-x;
-    }
+  main .hero picture::after {
+    display: block;
+    content: '';
+    position: absolute;
+    top: 50%;
+    bottom: 0;
+    right: 0;
+    left: 0;
+    background: linear-gradient(-180deg, rgb(0 0 0 / 0%), rgb(0 0 0 / 80%)) repeat-x;
+  }
 }
 
 @media screen and (min-width: 768px) {
-    main .hero-headings {
-        padding-top: 48px;
-        top: 0;
-        bottom: unset;
-    }
+  main .hero-headings {
+    padding-top: 48px;
+    top: 0;
+    bottom: unset;
+  }
 
-    main .hero-headings:has(.button) h1 {
-        margin-block-end: 24px;
-    }
+  main .hero-headings:has(.button) h1 {
+    margin-block-end: 24px;
+  }
 
-    main .hero-headings a.cta {
-        padding: var(--btn-padding);
-        color: var(--text-color);
-        background-color: var(--c-white);
-        border: 2px solid var(--c-white);
-    }
+  main .hero-headings a.cta {
+    padding: var(--btn-padding);
+    color: var(--text-color);
+    background-color: var(--c-white);
+    border: 2px solid var(--c-white);
+  }
 
-    main .hero-headings a.cta:hover {
-        background-color: var(--btn-background-hover);
-        border-color: #e0e0e0;
-    }
+  main .hero-headings a.cta:hover {
+    background-color: var(--btn-background-hover);
+    border-color: #e0e0e0;
+  }
 
-    main .hero picture::after {
-        top: 0;
-        background-image: linear-gradient(-30deg,rgba(0 0 0 / 0%),rgba(0 0 0 / 40%));
-    }
+  main .hero picture::after {
+    top: 0;
+    background-image: linear-gradient(-30deg, rgba(0 0 0 / 0%), rgba(0 0 0 / 40%));
+  }
 
-    main .hero-with-video picture img {
-        height: 730px;
-        max-height: 730px;
-    }
+  main .hero-with-video picture img {
+    height: 730px;
+    max-height: 730px;
+  }
 
-    main .hero-with-video .hero-video {
-        height: 730px;
-        max-height: 730px;
-    }
+  main .hero-with-video .hero-video {
+    height: 730px;
+    max-height: 730px;
+  }
 
-    main .hero-with-video .hero-headings {
-        top: 50%;
-        padding-top: 0;
-        transform: translateY(-50%);
-    }
+  main .hero-with-video .hero-headings {
+    top: 50%;
+    padding-top: 0;
+    transform: translateY(-50%);
+  }
 }
 
 @media screen and (min-width: 992px) {
-    main .hero-headings {
-        width: 913px;
-        left: 50%;
-        transform: translateX(-50%);
-        padding-left: 47px;
-        text-align: left;
-    }
+  main .hero-headings {
+    width: 913px;
+    left: 50%;
+    transform: translateX(-50%);
+    padding-left: 47px;
+    text-align: left;
+  }
 
-    main .hero-with-video .hero-headings {
-        top: 50%;
-        padding-top: 0;
-        transform: translate(-50%, -50%);
-    }
+  main .hero-with-video .hero-headings {
+    top: 50%;
+    padding-top: 0;
+    transform: translate(-50%, -50%);
+  }
 }
 
 @media screen and (min-width: 1300px) {
-    main .hero-headings {
-        width: 1153px;
-    }
+  main .hero-headings {
+    width: 1153px;
+  }
 
-    main .hero-with-video .hero-headings {
-        transform: translate(40%, -50%);
-        top: 50%;
-        left: 0;
-    }
+  main .hero-with-video .hero-headings {
+    transform: translate(40%, -50%);
+    top: 50%;
+    left: 0;
+  }
 }
 
 /* hero large version */
@@ -223,7 +223,7 @@ main .hero.hero-large .hero-headings h4 {
 }
 
 main .hero.hero-large .hero-headings h1 {
-  font-family: var(--heading-font-family);
+  font-family: var(--font-family-heading);
   line-height: var(--heading-ml-line-height);
   font-size: var(--heading-ml-font-size);
   letter-spacing: var(--heading-ml-letter-spacing);

--- a/blocks/key-facts/key-facts.css
+++ b/blocks/key-facts/key-facts.css
@@ -98,7 +98,7 @@
   margin: 0 auto;
   width: 20%;
   padding-top: 30px;
-  border-top: 3px solid #E1DFDD;
+  border-top: 3px solid var(--c-grey-1);
 }
 
 @media screen and (min-width: 576px) {

--- a/blocks/magazine-articles/magazine-articles.css
+++ b/blocks/magazine-articles/magazine-articles.css
@@ -84,7 +84,7 @@
 
 /* Latest magazine articles */
 .block.latest .latest-magazine-articles article .content h3 a {
-    color: var(--link-color);
+    color: var(--c-cta-blue-default);
     font-weight: 700;
     border: none;
     padding: 0;

--- a/blocks/photosphere/photosphere.css
+++ b/blocks/photosphere/photosphere.css
@@ -10,5 +10,5 @@ main .section .photosphere-wrapper {
 }
 
 .psv-loader-text {
-  color: var(--volvo-text-black);
+  color: var(--c-black);
 }

--- a/blocks/press-releases/press-releases.css
+++ b/blocks/press-releases/press-releases.css
@@ -43,7 +43,7 @@
 }
 
 .block.press-releases p.button-container a:hover {
-    background-color: var(--background-hover-color);
+    background-color: var(--c-grey-1);
 }
 
 .block.press-releases .list-filter input,
@@ -72,7 +72,7 @@
 }
 
 .block.press-releases .search-field button {
-    background-color: var(--link-color);
+    background-color: var(--c-cta-blue-default);
     color: var(--c-white);
     border: 0;
 }
@@ -107,7 +107,7 @@
 .block.press-releases .tags-field select {
     width: 100%;
     appearance: none;
-    background-color: var(--link-color);
+    background-color: var(--c-cta-blue-default);
     color: var(--c-white);
     padding: 15px 40px 15px 15px;
 }

--- a/blocks/search-results/search-results.css
+++ b/blocks/search-results/search-results.css
@@ -225,7 +225,7 @@
   width: calc(100%);
   top: 42px;
   background-color: #fff;
-  color: #53565a;
+  color: var(--c-grey-4);
   cursor: pointer;
   margin-top: 16px;
   z-index: 999;
@@ -254,7 +254,7 @@
   .search-wrapper
   .studio-widget-autosuggest-results
   .result-row.searchstudio-active-row {
-  color: #53565a;
+  color: var(--c-grey-4);
   cursor: pointer;
   background: #f2f2f2;
 }
@@ -413,7 +413,7 @@
   }
 
   .studio-search-widget .search-wrapper .studio-widget-search-input {
-    border: 1px solid #E1DFDD;
+    border: 1px solid var(--c-grey-1);
   }
 }
 
@@ -439,7 +439,7 @@
   padding: 20px 12px;
   color: #33475a;
   border: none;
-  border-top: 1px solid #f1f0ef;
+  border-top: 1px solid var(--c-grey-1);
 }
 
 .card-searchstudio-js-custom.has-thumbnail {
@@ -582,7 +582,7 @@
   .card-searchstudio-js-body
   .card-searchstudio-js-body {
   width: 100%;
-  color: #53565a;
+  color: var(--c-grey-4);
 }
 
 .card-searchstudio-js-custom
@@ -696,7 +696,7 @@
 
 .search-feedback-filters-custom strong {
   font-weight: 500;
-  font-family: var(--fixed-font-family);
+  font-family: var(--font-family-fixed);
 }
 
 @media (max-width: 1199px) {
@@ -1800,7 +1800,7 @@
     text-transform: uppercase;
     color: #33475a;
     padding: 20px 40px;
-    border-bottom: 1px solid #53565a;
+    border-bottom: 1px solid var(--c-grey-4);
     align-self: flex-end;
   }
 

--- a/blocks/specifications/specifications.css
+++ b/blocks/specifications/specifications.css
@@ -43,7 +43,7 @@
 }
 
 .block.specifications .column-header .cell {
-    background-color: #53565A;
+    background-color: var(--c-grey-4);
     color: white;
 }
 
@@ -96,7 +96,7 @@
 }
 
 .block.specifications .rowgroup-header:hover {
-    background-color: #E1DFDD;
+    background-color: var(--c-grey-1);
 }
 
 .block.specifications .rowgroup-header::after {
@@ -115,7 +115,7 @@
 }
 
 .block.specifications .column-header-mobile select {
-    background-color: #53565A;
+    background-color: var(--c-grey-4);
     color: white;
     width: 100%;
     padding: 15px;

--- a/blocks/text/text.css
+++ b/blocks/text/text.css
@@ -57,7 +57,7 @@ div.text.xxs p {
 }
 
 div.text.black {
-    color: var(--volvo-text-black);
+    color: var(--c-black);
 }
 
 div.text.alert.block {

--- a/common/modal/modal.css
+++ b/common/modal/modal.css
@@ -26,7 +26,7 @@
   position: relative;
   transform: translateY(-100vh);
   transition: transform 0.3s ease-out;
-  background-color: #e1dfdd;
+  background-color: var(--c-grey-1);
 }
 
 .modal-content .modal-video {

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -48,55 +48,50 @@
   --ff-volvo-novum: 'VolvoNovum', 'VolvoNovum Fallback', sans-serif;
   --ff-volvo-broadprodigital: 'VolvoBroadProDigital', 'VolvoBroadProDigital Fallback', sans-serif;
   --ff-fontawesome: 'fontawesome', 'fontawesome Fallback';
-
   --font-family-body: var(--ff-volvo-novum);
   --font-family-heading: var(--ff-volvo-novum-medium);
   --font-family-fixed: 'Roboto Mono', menlo, consolas, 'Liberation Mono', monospace;
 
   /* REDESIGN */
   /* Volvo Broad Pro Digital, 60px,Uppercase, 3.6px,#53565A */
-  --f-large-title--font-size: 3.75rem;
-  --f-large-title--text-transform: uppercase;
-  --f-large-title--letter-spacing: 3.6px;
+  --f-large-title-font-size: 3.75rem;
+  --f-large-title-text-transform: uppercase;
+  --f-large-title-letter-spacing: 3.6px;
 
   /* Volvo Novum Medium, 48px, -0.1px, #53565A */
-  --f-large-text--font-size: 3rem;
-  --f-large-text--letter-spacing: -0.1px;
+  --f-large-text-font-size: 3rem;
+  --f-large-text-letter-spacing: -0.1px;
 
   /* Volvo Broad Pro Digital, 48px,Uppercase, 3.6px,#53565A */
-  --f-medium-title--font-size: 3rem;
-  --f-medium-title--text-transform: uppercase;
-  --f-medium-title--letter-spacing: 3.6px;
+  --f-medium-title-font-size: 3rem;
+  --f-medium-title-text-transform: uppercase;
+  --f-medium-title-letter-spacing: 3.6px;
 
   /* Volvo Novum Medium, 32px, , -0.1px, #53565A */
-  --f-medium-text--font-size: 2rem;
-  --f-medium-text--letter-spacing: -0.1px;
+  --f-medium-text-font-size: 2rem;
+  --f-medium-text-letter-spacing: -0.1px;
 
   /* Volvo Novum Medium, 24px, , -0.1px, #53565A */
   /* Volvo Novum Regular, 24px, , -0.1px, #53565A */
-  --f-small--font-size: 1.5rem;
-  --f-small--letter-spacing: -0.1px;
+  --f-small-font-size: 1.5rem;
+  --f-small-letter-spacing: -0.1px;
 
   /* Volvo Novum Medium, 16px, , -0.1px, #53565A */
-  --f-xsmall--font-size: 1rem;
-  --f-xsmall--letter-spacing: -0.1px;
+  --f-xsmall-font-size: 1rem;
+  --f-xsmall-letter-spacing: -0.1px;
 
   /* Volvo Novum Medium, 12px, , -0.1px, #53565A */
-  --f-xxsmall--font-size: 0.75rem;
-  --f-xxsmall--letter-spacing: -0.1px;
-
   /* Volvo Novum Regular, 12px, , -0.1px, #53565A */
-  --f-xxsmall--font-size: 0.75rem;
-  --f-xxsmall--letter-spacing: -0.1px;
+  --f-xxsmall-font-size: 0.75rem;
+  --f-xxsmall-letter-spacing: -0.1px;
 
   /* Volvo Novum Regular, 16px, -0.1px,  #53565A */
-  --f-body-text--font-size: var(--f-xsmall-title--font-size);
-  --f-body-text--letter-spacing: var(--f-xsmall-title--letter-spacing);
+  --f-body-text-font-size: var(--f-xsmall-title--font-size);
+  --f-body-text-letter-spacing: var(--f-xsmall-title--letter-spacing);
 
   /* COLORS */
-  --c-black: #000000;
-  --c-white: #ffffff;
-
+  --c-black: #000;
+  --c-white: #fff;
   --c-volvo-blue: #182871;
   --c-dark-blue: #202A44;
   --c-leaf-one: #C8E691;
@@ -226,7 +221,7 @@ body {
   color: var(--text-color);
   display: none;
   font-family: var(--font-family-body);
-  font-size: var(--f-body-text--font-size);
+  font-size: var(--f-body-text-font-size);
   line-height: 1.5;
   margin: 0;
   -moz-osx-font-smoothing: grayscale;

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -55,33 +55,33 @@
   /* REDESIGN */
 
   /* Volvo Broad Pro Digital, 60px, Uppercase, 3.6px,#53565A */
-  --f-large-title-font-size: 3.75rem;
+  --f-large-title-font-size: 6rem;
   --f-large-title-text-transform: uppercase;
   --f-large-title-letter-spacing: 3.6px;
 
   /* Volvo Novum Medium, 48px, -0.1px, #53565A */
-  --f-large-text-font-size: 3rem;
+  --f-large-text-font-size: 4.8rem;
   --f-large-text-letter-spacing: -0.1px;
 
   /* Volvo Broad Pro Digital, 48px,Uppercase, 3.6px,#53565A */
-  --f-medium-title-font-size: 3rem;
+  --f-medium-title-font-size: 4.8rem;
   --f-medium-title-text-transform: uppercase;
   --f-medium-title-letter-spacing: 3.6px;
 
   /* Volvo Novum Medium, 32px, , -0.1px, #53565A */
-  --f-medium-text-font-size: 2rem;
+  --f-medium-text-font-size: 3.2rem;
   --f-medium-text-letter-spacing: -0.1px;
 
   /* Volvo Novum Medium / Volvo Novum Regular, 24px, , -0.1px, #53565A */
-  --f-small-font-size: 1.5rem;
+  --f-small-font-size: 2.4rem;
   --f-small-letter-spacing: -0.1px;
 
   /* Volvo Novum Medium, 16px, , -0.1px, #53565A */
-  --f-xsmall-font-size: 1rem;
+  --f-xsmall-font-size: 1.6rem;
   --f-xsmall-letter-spacing: -0.1px;
 
   /* Volvo Novum Medium / Volvo Novum Regular, 12px, , -0.1px, #53565A */
-  --f-xxsmall-font-size: 0.75rem;
+  --f-xxsmall-font-size: 1.2rem;
   --f-xxsmall-letter-spacing: -0.1px;
 
   /* Volvo Novum Regular, 16px, -0.1px,  #53565A */
@@ -213,7 +213,7 @@
 }
 
 html {
-  font-size: 16px;
+  font-size: 10px;
 }
 
 body {

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -53,7 +53,8 @@
   --font-family-fixed: 'Roboto Mono', menlo, consolas, 'Liberation Mono', monospace;
 
   /* REDESIGN */
-  /* Volvo Broad Pro Digital, 60px,Uppercase, 3.6px,#53565A */
+
+  /* Volvo Broad Pro Digital, 60px, Uppercase, 3.6px,#53565A */
   --f-large-title-font-size: 3.75rem;
   --f-large-title-text-transform: uppercase;
   --f-large-title-letter-spacing: 3.6px;
@@ -71,8 +72,7 @@
   --f-medium-text-font-size: 2rem;
   --f-medium-text-letter-spacing: -0.1px;
 
-  /* Volvo Novum Medium, 24px, , -0.1px, #53565A */
-  /* Volvo Novum Regular, 24px, , -0.1px, #53565A */
+  /* Volvo Novum Medium / Volvo Novum Regular, 24px, , -0.1px, #53565A */
   --f-small-font-size: 1.5rem;
   --f-small-letter-spacing: -0.1px;
 
@@ -80,14 +80,13 @@
   --f-xsmall-font-size: 1rem;
   --f-xsmall-letter-spacing: -0.1px;
 
-  /* Volvo Novum Medium, 12px, , -0.1px, #53565A */
-  /* Volvo Novum Regular, 12px, , -0.1px, #53565A */
+  /* Volvo Novum Medium / Volvo Novum Regular, 12px, , -0.1px, #53565A */
   --f-xxsmall-font-size: 0.75rem;
   --f-xxsmall-letter-spacing: -0.1px;
 
   /* Volvo Novum Regular, 16px, -0.1px,  #53565A */
-  --f-body-text-font-size: var(--f-xsmall-title--font-size);
-  --f-body-text-letter-spacing: var(--f-xsmall-title--letter-spacing);
+  --f-body-text-font-size: var(--f-xsmall-font-size);
+  --f-body-text-letter-spacing: var(--f-xsmall-letter-spacing);
 
   /* COLORS */
   --c-black: #000;
@@ -149,6 +148,7 @@
   --body-font-size-xxs: 1.3rem;
 
   /* heading sizes */
+
   /* the scale allows us to adjust all heading sizes but preserve the ratio */
   --heading-font-size-scale: 0.5;
   --heading-font-size-xxl: calc(7.2rem * var(--heading-font-size-scale));
@@ -163,6 +163,7 @@
     NEW heading sizes (for redesign)
     names in brackends refers to names on the desing
    */
+
   /* XXL (Section header/Heading 1) */
   --heading-xxl-font-size: 7.2rem;
   --heading-xxl-line-height: 1;

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -93,18 +93,18 @@
   --c-white: #fff;
   --c-volvo-blue: #182871;
   --c-dark-blue: #202A44;
-  --c-leaf-one: #C8E691;
-  --c-leaf-two: #A8D46B;
-  --c-leaf-three: #8FC54E;
-  --c-leaf-four: #78B833;
-  --c-teal-one: #B8DeD8;
-  --c-teal-two: #8DC9BF;
-  --c-teal-three: #66B3A6;
-  --c-teal-four: #50A294;
-  --c-flow-one: #396976;
-  --c-flow-two: #678C96;
-  --c-flow-three: #96B0B6;
-  --c-flow-four: #C3D2D6;
+  --c-leaf-1: #C8E691;
+  --c-leaf-2: #A8D46B;
+  --c-leaf-3: #8FC54E;
+  --c-leaf-4: #78B833;
+  --c-teal-1: #B8DeD8;
+  --c-teal-2: #8DC9BF;
+  --c-teal-3: #66B3A6;
+  --c-teal-4: #50A294;
+  --c-flow-1: #396976;
+  --c-flow-2: #678C96;
+  --c-flow-3: #96B0B6;
+  --c-flow-4: #C3D2D6;
   --c-cta-blue-default: #004FBC;
   --c-cta-blue-hover: #0056D6;
   --c-cta-blue-active: #0041A3;
@@ -115,19 +115,18 @@
   --c-grey-3: #888B8D;
   --c-grey-4: #53565A;
 
-  /* 
+  /* Success / error colors */
   --c-error-red: #C4001A;
-  --c-success-green : #47962D
-  --c-warning-yellow: #F7D302
-   */
+  --c-success-green : #47962D;
+  --c-warning-yellow: #F7D302;
 
+  /* Global colors */
   --volvo-text-gray: var(--c-grey-4);
   --volvo-text-light-gray: var(--c-grey-2);
   --text-color: var(--c-grey-4);
   --btn-background-hover: var(--c-grey-1);
   --input-background-color: var(--c-grey-1);
   --overlay-background-color: var(--c-grey-1);
-
 
   /*
     OLD styles

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -1,16 +1,3 @@
-/* stylelint-disable comment-empty-line-before */
-/*
- * Copyright 2020 Adobe. All rights reserved.
- * This file is licensed to you under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License. You may obtain a copy
- * of the License at http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under
- * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
- * OF ANY KIND, either express or implied. See the License for the specific language
- * governing permissions and limitations under the License.
- */
-
 /*
    Fonts
    When using fonts, please see "best practices for fonts" in Readme
@@ -56,32 +43,106 @@
 }
 
  :root {
-  /* colors */
-  --c-white: #fff;
-  --link-color: #004FBC;
-  --link-hover-color: #0b326f;
-  --background-color: var(--c-white);
-  --background-hover-color: #E1DFDD;
-  --background-light-gray: #ebebeb;
-  --overlay-background-color: #eee;
-  --highlight-background-color: #ccc;
-  --volvo-text-gray: #53565A;
-  --volvo-text-black: #000;
-  --volvo-text-light-gray: #A7A8A9;
-  --text-color: var(--volvo-text-gray);
-  --btn-background-hover: #e1dfdd;
-  --btn-border-hover: #030333;
-  --input-background-color: #f1f0ef;
-
   /* fonts */
   --ff-volvo-novum-medium: 'VolvoNovum-Medium', 'VolvoNovum-Medium Fallback', sans-serif;
   --ff-volvo-novum: 'VolvoNovum', 'VolvoNovum Fallback', sans-serif;
   --ff-volvo-broadprodigital: 'VolvoBroadProDigital', 'VolvoBroadProDigital Fallback', sans-serif;
   --ff-fontawesome: 'fontawesome', 'fontawesome Fallback';
-  --body-font-family: var(--ff-volvo-novum);
-  --heading-font-family: var(--ff-volvo-novum-medium);
-  --fixed-font-family: 'Roboto Mono', menlo, consolas, 'Liberation Mono', monospace;
 
+  --font-family-body: var(--ff-volvo-novum);
+  --font-family-heading: var(--ff-volvo-novum-medium);
+  --font-family-fixed: 'Roboto Mono', menlo, consolas, 'Liberation Mono', monospace;
+
+  /* REDESIGN */
+  /* Volvo Broad Pro Digital, 60px,Uppercase, 3.6px,#53565A */
+  --f-large-title--font-size: 3.75rem;
+  --f-large-title--text-transform: uppercase;
+  --f-large-title--letter-spacing: 3.6px;
+
+  /* Volvo Novum Medium, 48px, -0.1px, #53565A */
+  --f-large-text--font-size: 3rem;
+  --f-large-text--letter-spacing: -0.1px;
+
+  /* Volvo Broad Pro Digital, 48px,Uppercase, 3.6px,#53565A */
+  --f-medium-title--font-size: 3rem;
+  --f-medium-title--text-transform: uppercase;
+  --f-medium-title--letter-spacing: 3.6px;
+
+  /* Volvo Novum Medium, 32px, , -0.1px, #53565A */
+  --f-medium-text--font-size: 2rem;
+  --f-medium-text--letter-spacing: -0.1px;
+
+  /* Volvo Novum Medium, 24px, , -0.1px, #53565A */
+  /* Volvo Novum Regular, 24px, , -0.1px, #53565A */
+  --f-small--font-size: 1.5rem;
+  --f-small--letter-spacing: -0.1px;
+
+  /* Volvo Novum Medium, 16px, , -0.1px, #53565A */
+  --f-xsmall--font-size: 1rem;
+  --f-xsmall--letter-spacing: -0.1px;
+
+  /* Volvo Novum Medium, 12px, , -0.1px, #53565A */
+  --f-xxsmall--font-size: 0.75rem;
+  --f-xxsmall--letter-spacing: -0.1px;
+
+  /* Volvo Novum Regular, 12px, , -0.1px, #53565A */
+  --f-xxsmall--font-size: 0.75rem;
+  --f-xxsmall--letter-spacing: -0.1px;
+
+  /* Volvo Novum Regular, 16px, -0.1px,  #53565A */
+  --f-body-text--font-size: var(--f-xsmall-title--font-size);
+  --f-body-text--letter-spacing: var(--f-xsmall-title--letter-spacing);
+
+  /* COLORS */
+  --c-black: #000000;
+  --c-white: #ffffff;
+
+  --c-volvo-blue: #182871;
+  --c-dark-blue: #202A44;
+  --c-leaf-one: #C8E691;
+  --c-leaf-two: #A8D46B;
+  --c-leaf-three: #8FC54E;
+  --c-leaf-four: #78B833;
+  --c-teal-one: #B8DeD8;
+  --c-teal-two: #8DC9BF;
+  --c-teal-three: #66B3A6;
+  --c-teal-four: #50A294;
+  --c-flow-one: #396976;
+  --c-flow-two: #678C96;
+  --c-flow-three: #96B0B6;
+  --c-flow-four: #C3D2D6;
+  --c-cta-blue-default: #004FBC;
+  --c-cta-blue-hover: #0056D6;
+  --c-cta-blue-active: #0041A3;
+
+  /* Greyscale */
+  --c-grey-1: #E1DFDD;
+  --c-grey-2: #A7A8A9;
+  --c-grey-3: #888B8D;
+  --c-grey-4: #53565A;
+
+  /* 
+  --c-error-red: #C4001A;
+  --c-success-green : #47962D
+  --c-warning-yellow: #F7D302
+   */
+
+  --volvo-text-gray: var(--c-grey-4);
+  --volvo-text-light-gray: var(--c-grey-2);
+  --text-color: var(--c-grey-4);
+  --btn-background-hover: var(--c-grey-1);
+  --input-background-color: var(--c-grey-1);
+  --overlay-background-color: var(--c-grey-1);
+
+
+  /*
+    OLD styles
+    we need to remove / update once they are not used in the styles
+  */
+  --background-light-gray: #ebebeb;
+  --highlight-background-color: #ccc;
+  --btn-border-hover: #030333;
+  
   /* buttons */
   --btn-padding: 12px 32px;
 
@@ -157,19 +218,19 @@
 }
 
 html {
-  font-size: 10px;
+  font-size: 16px;
 }
 
 body {
-  font-size: var(--body-font-size-m);
-  margin: 0;
-  font-family: var(--body-font-family);
-  line-height: 1.5;
+  background-color: var(--c-white);
   color: var(--text-color);
-  background-color: var(--background-color);
   display: none;
-  -webkit-font-smoothing: antialiased;
+  font-family: var(--font-family-body);
+  font-size: var(--f-body-text--font-size);
+  line-height: 1.5;
+  margin: 0;
   -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
 }
 
 body.appear {
@@ -208,7 +269,7 @@ main.center :where(.block) { text-align: initial; }
 
 h1, h2, h3,
 h4, h5, h6 {
-  font-family: var(--heading-font-family);
+  font-family: var(--font-family-heading);
   font-weight: normal;
   line-height: 1;
   margin: 0;
@@ -281,13 +342,13 @@ p, dl, ol, ul, pre, blockquote {
 }
 
 a:any-link {
-  color: var(--link-color);
+  color: var(--c-cta-blue-default);
   text-decoration: none;
 }
 
 a:hover {
   text-decoration: none;
-  color: var(--link-hover-color);
+  color: var(--c-cta-blue-hover);
 }
 
 :is(h1, h2, h3, h4, h5, h6) a:any-link {
@@ -299,11 +360,11 @@ a:hover {
 }
 
 :is(h1, h2, h3, h4, h5, h6) a:any-link::after {
-  color: var(--link-color);
+  color: var(--c-cta-blue-default);
 }
 
 code, pre, samp {
-  font-family: var(--fixed-font-family);
+  font-family: var(--font-family-fixed);
   font-size: var(--body-font-size-s);
 }
 
@@ -400,7 +461,7 @@ main input {
   box-sizing: border-box;
   border: 1px solid var(--text-color);
   color: var(--text-color);
-  background-color: var(--background-color);
+  background-color: var(--c-white);
 }
 
 main input:hover {
@@ -560,7 +621,7 @@ main .section.tabbed-container ul.tab-navigation button {
 
 .section.tabbed-container ul.tab-navigation li.active,
 .section.tabbed-container ul.tab-navigation li:hover {
-  border-bottom: 3px solid var(--link-color);
+  border-bottom: 3px solid var(--c-cta-blue-default);
 }
 
 /* image as video link */
@@ -632,7 +693,7 @@ a.button.text-link-with-video::after {
 /* video low resolution banner */
 .low-resolution-banner {
   font-size: 16px;
-  background: var(--background-color);
+  background: var(--c-white);
   text-align: center;
   display: flex;
   justify-content: center;
@@ -642,7 +703,7 @@ a.button.text-link-with-video::after {
 .low-resolution-banner-cookie-settings {
   border: none;
   background: transparent;
-  color: #0d3c87;
+  color: var(--c-dark-blue);
   text-decoration: underline;
   font-size: 16px;
   font-weight: 400;
@@ -752,7 +813,7 @@ div.block div.pager .pagination .scroll li a {
   }
 
   header .sub-nav.block {
-    background-color: #53565A;
+    background-color: var(--c-grey-4);
   }
 }
 

--- a/templates/magazine/magazine.css
+++ b/templates/magazine/magazine.css
@@ -119,7 +119,7 @@ body.magazine>main .share {
 }
 
 body.magazine>main .section.template.article-sidebar>div.subscribe {
-  border-top: 1px solid var(--background-hover-color);
+  border-top: 1px solid var(--c-grey-1);
   padding-top: 30px;
   margin-top: 30px;
 }
@@ -179,7 +179,7 @@ body.magazine>main div.default-content-wrapper>blockquote>p::after {
 }
 
 div.section.related-articles-container {
-  border-top: 1px solid var(--background-hover-color);
+  border-top: 1px solid var(--c-grey-1);
   display: inline-block;
   width: 100%;
 }
@@ -250,8 +250,8 @@ div.section.eloqua-form-container>div.eloqua-form-wrapper {
 
   body.magazine>main .section.template.article-hero>div>div.content {
     order: 2;
-    border-top: 1px solid var(--background-hover-color);
-    border-bottom: 1px solid var(--background-hover-color);
+    border-top: 1px solid var(--c-grey-1);
+    border-bottom: 1px solid var(--c-grey-1);
     flex: 0 0 50%;
     max-width: 50%;
     padding: 30px 45px;

--- a/tools/sidekick/library.html
+++ b/tools/sidekick/library.html
@@ -16,7 +16,7 @@
         margin: 0;
         padding: 0;
         font-family: sans-serif;
-        background-color: #ededed;
+        background-color: var(--c-grey-1);
         height: 100%;
       }
       


### PR DESCRIPTION
- Creating new variables following redesign style guide (https://ncchat.slack.com/archives/C04G7PQ5QG3/p1689926806604239)
- We are keeping some OLD styles in file `styles/styles.css` in line 138. We will need to get rid of them as soon as we are working in the blocks. Because those variables are still used in specific blocks.
- We are reading the colour variables in JS files.
- All colour variables start with `--c-mycolorname`, font start with `--f-myfontname` so we know what is that variable containing.

Test URLs:
- Before: https://main--vg-volvotrucks-us-rd--netcentric.hlx.page/
- After: https://feature-setup-style-guide--vg-volvotrucks-us-rd--netcentric.hlx.page/

Removed from the PR:
- Changed base unit for the system to 16 pixels instead of 10px, because in Volvo group they are using 16px (https://www.volvogroup.com/experiencesystem/en/#/brand/615bfcc428c818001105b4e3/61a0de32a7047974164f01dd/622b4df837a675408d76ebfd) this can cause, that old styles might look bigger. **UPDATE:** we will keep 10px because old & new web need to coexist.
