### PR TITLE
109 add pretitle to blocks

### DIFF
--- a/blocks/v2-section-header/v2-section-header.css
+++ b/blocks/v2-section-header/v2-section-header.css
@@ -1,0 +1,46 @@
+.v2-section-header {
+  margin: 0 auto;
+  font-size: var(--heading-s-font-size);
+  line-height: var(--heading-s-line-height);
+  letter-spacing: var(--heading-s-letter-spacing);
+  text-align: center;
+  text-wrap: balance;
+}
+
+.v2-section-header > *:first-child {
+  margin-top: 0;
+}
+
+.v2-section-header > *:last-child {
+  margin-bottom: 0;
+}
+
+.v2-section-header__title {
+  font-size: var(--f-heading-4-font-size);
+  letter-spacing: var(--f-heading-4-letter-spacing);
+  line-height: var(--f-heading-4-line-height);
+}
+
+@media (min-width: 744px) {
+  .v2-section-header {
+    max-width: 506px;
+  }
+}
+
+@media (min-width: 1200px) {
+  .v2-section-header {
+    max-width: 694px;
+  }
+
+  .v2-section-header__title {
+    font-size: var(--f-heading-3-font-size);
+    letter-spacing: var(--f-heading-3-letter-spacing);
+    line-height: var(--f-heading-3-line-height);
+  }
+
+  .v2-section-header p {
+    font-size: var(--f-body-2-font-size);
+    letter-spacing: var(--f-body-2-letter-spacing);
+    line-height: var(--f-body-2-line-height);
+  }  
+}

--- a/blocks/v2-section-header/v2-section-header.js
+++ b/blocks/v2-section-header/v2-section-header.js
@@ -1,0 +1,34 @@
+import { adjustPretitle } from '../../scripts/common.js';
+
+export default function decorate(block) {
+  const blockName = 'v2-section-header';
+  const content = block.querySelector(':scope > div > div');
+  adjustPretitle(content);
+
+  const headings = content.querySelectorAll('h1, h2, h3, h4, h5, h6');
+  [...headings].forEach((heading) => heading.classList.add(`${blockName}__title`));
+
+  const buttons = content.querySelectorAll('.button-container > a');
+  [...buttons].forEach((button) => {
+    button.classList.remove('primary');
+    button.classList.add('tertiary');
+  });
+
+  // Function to unwrap <div> tags
+  function unwrapDivs(element) {
+    Array.from(element.children).forEach((node) => {
+      if (node.tagName === 'DIV' && node.attributes.length === 0) {
+        while (node.firstChild) {
+          element.insertBefore(node.firstChild, node);
+        }
+        node.remove();
+        unwrapDivs(element);
+      } else {
+        unwrapDivs(node);
+      }
+    });
+  }
+
+  // Unwrap <div> tags
+  unwrapDivs(block);
+}

--- a/blocks/v2-section-header/v2-section-header.js
+++ b/blocks/v2-section-header/v2-section-header.js
@@ -1,4 +1,4 @@
-import { adjustPretitle } from '../../scripts/common.js';
+import { adjustPretitle, unwrapDivs } from '../../scripts/common.js';
 
 export default function decorate(block) {
   const blockName = 'v2-section-header';
@@ -13,21 +13,6 @@ export default function decorate(block) {
     button.classList.remove('primary');
     button.classList.add('tertiary');
   });
-
-  // Function to unwrap <div> tags
-  function unwrapDivs(element) {
-    Array.from(element.children).forEach((node) => {
-      if (node.tagName === 'DIV' && node.attributes.length === 0) {
-        while (node.firstChild) {
-          element.insertBefore(node.firstChild, node);
-        }
-        node.remove();
-        unwrapDivs(element);
-      } else {
-        unwrapDivs(node);
-      }
-    });
-  }
 
   // Unwrap <div> tags
   unwrapDivs(block);

--- a/blocks/v2-text-with-images/v2-text-with-images.css
+++ b/blocks/v2-text-with-images/v2-text-with-images.css
@@ -123,7 +123,7 @@
   .v2-text-with-images__col {
     align-self: flex-start;
     position: sticky;
-    top: var(--nav-height);
+    top: calc(var(--nav-height) + var(--inpage-navigation-height) + 8px);
     text-align: left;
     align-items: flex-start;
     width: 360px;
@@ -147,8 +147,11 @@
     margin: 16px 0 24px;
   }
 
-  .v2-text-with-images__text {
+  p.v2-text-with-images__text {
     margin: 0 0 32px;
+    font-size: var(--f-body-2-font-size);
+    letter-spacing: var(--f-body-2-letter-spacing);
+    line-height: var(--f-body-2-line-height);
   }
 
   .v2-text-with-images__images-list-item {

--- a/scripts/common.js
+++ b/scripts/common.js
@@ -151,6 +151,20 @@ export const removeEmptyTags = (block) => {
   });
 };
 
+export const unwrapDivs = (element) => {
+  Array.from(element.children).forEach((node) => {
+    if (node.tagName === 'DIV' && node.attributes.length === 0) {
+      while (node.firstChild) {
+        element.insertBefore(node.firstChild, node);
+      }
+      node.remove();
+      unwrapDivs(element);
+    } else {
+      unwrapDivs(node);
+    }
+  });
+};
+
 export const variantsClassesToBEM = (blockClasses, expectedVariantsNames, blockName) => {
   expectedVariantsNames.forEach((variant) => {
     if (blockClasses.contains(variant)) {

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -74,7 +74,7 @@
 
   /* Volvo Novum, 56px / 3.5rem, Light, -0.5px / 0.031rem, 110% */
   --f-heading-2-font-size: 3.5rem; /* 56px */
-  --f-heading-2-letter-spacing: 0.031rem;
+  --f-heading-2-letter-spacing: 0.03125rem;
   --f-heading-2-line-height: 110%;
 
   /* Volvo Novum, 48px / 3rem, Medium, 0px, 110% */
@@ -89,7 +89,7 @@
 
   /* Volvo Novum Web Latin, 32px / 2rem, Medium, 0.25px / 0.016rem, 125% */
   --f-heading-4-font-size: 2rem; /* 32px */
-  --f-heading-4-letter-spacing: 0.016rem;
+  --f-heading-4-letter-spacing: 0.015625rem;
   --f-heading-4-line-height: 125%;
 
   /* Volvo Novum, 24px / 1.5rem, Light, 0px, 125% */
@@ -99,12 +99,12 @@
 
   /* Volvo Novum, 20px / 1.25rem, Medium, 0.15px / 0.009rem, 125% */
   --f-heading-6-font-size: 1.25rem; /* 20px */
-  --f-heading-6-letter-spacing: 0.009rem;
+  --f-heading-6-letter-spacing: 0.009375rem;
   --f-heading-6-line-height: 125%;
 
   /* Volvo Novum, 16px / 1rem, Medium, 0.15px / 0.009rem, 130% */
   --f-subtitle-1-font-size: 1rem; /* 16px */
-  --f-subtitle-1-letter-spacing: 0.009rem;
+  --f-subtitle-1-letter-spacing: 0.009375rem;
   --f-subtitle-1-line-height: 130%;
 
   /* Volvo Novum, 14px / 0.875rem, Medium, 0.15px / 0.009rem, 130% */
@@ -114,7 +114,7 @@
 
   /* Volvo Novum, 16px / 1rem, Regular, 0.5px / 0.031rem, 130% */
   --f-body-font-size: 1rem; /* 16px */
-  --f-body-letter-spacing: 0.031rem;
+  --f-body-letter-spacing: 0.03125rem;
   --f-body-line-height: 130%;
 
   /* Volvo Novum, 18px / 1.125rem, Regular, 0.5px / 0.03125rem, 144% */
@@ -124,7 +124,7 @@
 
   /* Volvo Novum, 14px / 0.875rem, Regular, 1.25px / 0.078rem, 130% */
   --f-button-font-size: 0.875rem; /* 14px */
-  --f-button-letter-spacing: 0.078rem;
+  --f-button-letter-spacing: 0.078125rem;
   --f-button-line-height: 130%;
 
   /* Volvo Novum, 14px / 0.875rem, Regular, 0.4px / 0.025rem, 125% */


### PR DESCRIPTION
Fix #109

Test URLs:
- Before: https://develop--vg-volvotrucks-us-rd--netcentric.hlx.page/drafts/syb/section-header-pretitle
- After: https://109-add-pretitle-to-blocks--vg-volvotrucks-us-rd--Netcentric.hlx.page/drafts/syb/section-header-pretitle

Instead of adjusting the text block, I’ve added a new block to comply with [the design](https://www.figma.com/file/Id3nd9kbfh8TpS1SfWhrW2/Volvo-Component-Library?type=design&node-id=397-800&mode=design&t=llkAVOvaBfOUCV5p-4).

On the test page, I’ve added other blocks which contain a pretitle. The hero and banner shouldn’t have one. The text-with-images block is also changed to align better with the design.