### PR TITLE
#129 Remove empty space between trucks lineup and dealer locator section

### DIFF
--- a/blocks/v2-dealer-locator-teaser/v2-dealer-locator-teaser.css
+++ b/blocks/v2-dealer-locator-teaser/v2-dealer-locator-teaser.css
@@ -59,6 +59,10 @@
 }
 
 @media (min-width: 744px) {
+  .section + .v2-dealer-locator-teaser-container {
+    margin-top: -56px;
+  }
+
   .v2-dealer-locator-teaser {
     height: 665px;
   }

--- a/blocks/v2-dealer-locator-teaser/v2-dealer-locator-teaser.css
+++ b/blocks/v2-dealer-locator-teaser/v2-dealer-locator-teaser.css
@@ -1,3 +1,7 @@
+.section + .v2-dealer-locator-teaser-container {
+  margin-top: -40px;
+}
+
 .v2-dealer-locator-teaser {
   height: 509px;
   display: flex;
@@ -67,6 +71,10 @@
 }
 
 @media (min-width: 1200px) {
+  .section + .v2-dealer-locator-teaser-container {
+    margin-top: -136px;
+  }
+
   .v2-dealer-locator-teaser {
     align-items: center;
     height: 792px;


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #129 

Test URLs:
- Before: https://develop--vg-volvotrucks-us-rd--netcentric.hlx.page/
- After: https://129-truck-lineup-space--vg-volvotrucks-us-rd--netcentric.hlx.page/
