### PR TITLE
#131 Fix displaying after element on safari

### DIFF
--- a/blocks/v2-truck-lineup/v2-truck-lineup.css
+++ b/blocks/v2-truck-lineup/v2-truck-lineup.css
@@ -79,6 +79,7 @@ main .section.v2-truck-lineup-container .v2-truck-lineup-wrapper {
   content: '';
   display: block;
   flex: 0 0 50vw;
+  min-height: 1px; /* In this case, Safari doesn't render element properly without height */
 }
 
 .v2-truck-lineup__image-item img {


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #131 

Test URLs:
- Before: https://develop--vg-volvotrucks-us-rd--netcentric.hlx.page/
- After: https://131-safari-truck-lineup--vg-volvotrucks-us-rd--netcentric.hlx.page/
