### PR TITLE
147 Bug - Major: new Volvo header has too much white padding under

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -891,7 +891,7 @@ div.block div.pager .pagination .scroll li a {
     --sub-nav-height: 48px;
   }
 
-  :root:not(.redesign-v2) main .section:first-child > :first-child {
+  :root:not(.redesign-v2) main:not(.remove-top-margin) .section:first-child > :first-child {
     margin-top: 30px;
   }
 


### PR DESCRIPTION
Add possibility to remove whitespace between header and first block. With the new header, we have no need for the top margin on some non-redesign pages.

Fix #147 

Test URLs:
- Before: https://develop--vg-volvotrucks-us-rd--netcentric.hlx.page/our-difference/
- After: https://147-header-block-whitespace--vg-volvotrucks-us-rd--netcentric.hlx.page/our-difference/
