### PR TITLE
Truck Carousel should always begin with VNL #217

### DIFF
--- a/blocks/v2-truck-lineup/v2-truck-lineup.js
+++ b/blocks/v2-truck-lineup/v2-truck-lineup.js
@@ -122,6 +122,12 @@ const listenScroll = (carousel) => {
     });
 
     elements.forEach((el) => io.observe(el));
+
+    // force to go to the first item on load
+    carousel.scrollTo({
+      left: 0,
+      behavior: 'instant',
+    });
   });
 };
 


### PR DESCRIPTION
Fix #217 

Test URLs:
- Before: https://main--vg-volvotrucks-us-rd--netcentric.hlx.page/
- After: https://217-truck-lineup-state--vg-volvotrucks-us-rd--netcentric.hlx.page/
