### PR TITLE
Lineup - Center aligned text Carousel Block variant #100

### DIFF
--- a/blocks/v2-truck-lineup/v2-truck-lineup.css
+++ b/blocks/v2-truck-lineup/v2-truck-lineup.css
@@ -299,13 +299,17 @@ ul.v2-truck-lineup__navigation {
     max-width: var(--wrapper-width);
   }
 
-  .v2-truck-lineup__content .default-content-wrapper {
+  .v2-truck-lineup__text {
+    max-width: 931px;
+  }
+
+  main:not(.truck-lineup-content-center) .v2-truck-lineup__content .default-content-wrapper {
     align-items: flex-start;
     display: grid;
     grid-template-columns: 1fr 567px 80px 430px 1fr;
   }
 
-  .v2-truck-lineup__text {
+  main:not(.truck-lineup-content-center) .v2-truck-lineup__text {
     width: 567px;
     max-width: none;
     margin: 0;
@@ -314,12 +318,12 @@ ul.v2-truck-lineup__navigation {
     grid-column: 2;
   }
 
-  .v2-truck-lineup__buttons-container,
-  .v2-truck-lineup__buttons-container .button-container {
+  main:not(.truck-lineup-content-center) .v2-truck-lineup__buttons-container,
+  main:not(.truck-lineup-content-center) .v2-truck-lineup__buttons-container .button-container {
     margin-top: 0;
   }
 
-  .v2-truck-lineup__buttons-container {
+  main:not(.truck-lineup-content-center) .v2-truck-lineup__buttons-container {
     justify-content: start;
     grid-column: 4;
   }


### PR DESCRIPTION
Fix #100

Test URLs:
- Before: https://main--vg-volvotrucks-us-rd--netcentric.hlx.page/pdp
- After: https://100-truck-lineup-center-text--vg-volvotrucks-us-rd--netcentric.hlx.page/pdp

By adding a class to the page metadata (truck-lineup-content-center), we can create a variant for the truck lineup.